### PR TITLE
Develop

### DIFF
--- a/psl-core/src/main/java/org/linqs/psl/util/RandUtils.java
+++ b/psl-core/src/main/java/org/linqs/psl/util/RandUtils.java
@@ -173,7 +173,7 @@ public final class RandUtils {
 
             tempIndex = indexes[i];
             indexes[i] = indexes[swapIndex];
-            indexes[swapIndex] = indexes[i];
+            indexes[swapIndex] = tempIndex;
         }
     }
 }


### PR DESCRIPTION
Fixed a bug in RandUtils pairedShuffleIndexes. 

The indices were not being swapped, instead  pairedShuffleIndexes() was duplicating the indexes[swapIndex] index.