### PR TITLE
Weight learning

### DIFF
--- a/psl-core/src/main/java/org/linqs/psl/application/inference/mpe/SGDInference.java
+++ b/psl-core/src/main/java/org/linqs/psl/application/inference/mpe/SGDInference.java
@@ -25,7 +25,6 @@ import org.linqs.psl.reasoner.Reasoner;
 import org.linqs.psl.reasoner.sgd.SGDReasoner;
 import org.linqs.psl.reasoner.sgd.term.SGDMemoryTermStore;
 import org.linqs.psl.reasoner.sgd.term.SGDTermGenerator;
-import org.linqs.psl.reasoner.term.MemoryTermStore;
 import org.linqs.psl.reasoner.term.TermGenerator;
 import org.linqs.psl.reasoner.term.TermStore;
 

--- a/psl-core/src/main/java/org/linqs/psl/model/rule/AbstractRule.java
+++ b/psl-core/src/main/java/org/linqs/psl/model/rule/AbstractRule.java
@@ -17,16 +17,25 @@
  */
 package org.linqs.psl.model.rule;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for all (first order, i.e., not ground) rules.
  */
 public abstract class AbstractRule implements Rule {
+    private static Map<Integer, AbstractRule> rules = new HashMap<Integer, AbstractRule>();
+
     protected final String name;
+
+    public static AbstractRule getRule(int hashcode) {
+        return rules.get(hashcode);
+    }
 
     public AbstractRule(String name) {
         this.name = name;
+        rules.put(System.identityHashCode(this), this);
     }
 
     public String getName() {

--- a/psl-core/src/main/java/org/linqs/psl/reasoner/admm/term/ADMMObjectiveTerm.java
+++ b/psl-core/src/main/java/org/linqs/psl/reasoner/admm/term/ADMMObjectiveTerm.java
@@ -18,8 +18,9 @@
 package org.linqs.psl.reasoner.admm.term;
 
 import org.linqs.psl.model.rule.GroundRule;
+import org.linqs.psl.model.rule.Rule;
+import org.linqs.psl.model.rule.WeightedRule;
 import org.linqs.psl.reasoner.function.FunctionComparator;
-import org.linqs.psl.model.rule.WeightedGroundRule;
 import org.linqs.psl.reasoner.term.Hyperplane;
 import org.linqs.psl.reasoner.term.ReasonerTerm;
 import org.linqs.psl.util.FloatMatrix;
@@ -60,7 +61,8 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
         SquaredHingeLossTerm,
     }
 
-    protected float weight;
+    protected final Rule rule;
+
     protected int size;
 
     protected float[] coefficients;
@@ -100,9 +102,11 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      * Construct an ADMM objective term by taking ownership of the hyperplane and all members of it.
      * Use the static creation methods.
      */
-    private ADMMObjectiveTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule,
+    private ADMMObjectiveTerm(Hyperplane<LocalVariable> hyperplane, Rule rule,
             boolean squared, boolean hinge,
             FunctionComparator comparator) {
+        this.rule = rule;
+
         this.squared = squared;
         this.hinge = hinge;
         this.comparator = comparator;
@@ -112,36 +116,30 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
         this.coefficients = hyperplane.getCoefficients();
         this.constant = hyperplane.getConstant();
 
-        if (groundRule instanceof WeightedGroundRule) {
-            this.weight = (float)((WeightedGroundRule)groundRule).getWeight();
-        } else {
-            this.weight = Float.POSITIVE_INFINITY;
-        }
-
         TermType termType = getTermType();
         if (termType == TermType.HingeLossTerm || termType == TermType.LinearConstraintTerm) {
             initUnitNormal();
         }
     }
 
-    public static ADMMObjectiveTerm createLinearConstraintTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule, FunctionComparator comparator) {
-        return new ADMMObjectiveTerm(hyperplane, groundRule, false, false, comparator);
+    public static ADMMObjectiveTerm createLinearConstraintTerm(Hyperplane<LocalVariable> hyperplane, Rule rule, FunctionComparator comparator) {
+        return new ADMMObjectiveTerm(hyperplane, rule, false, false, comparator);
     }
 
-    public static ADMMObjectiveTerm createLinearLossTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule) {
-        return new ADMMObjectiveTerm(hyperplane, groundRule, false, false, null);
+    public static ADMMObjectiveTerm createLinearLossTerm(Hyperplane<LocalVariable> hyperplane, Rule rule) {
+        return new ADMMObjectiveTerm(hyperplane, rule, false, false, null);
     }
 
-    public static ADMMObjectiveTerm createHingeLossTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule) {
-        return new ADMMObjectiveTerm(hyperplane,groundRule, false, true, null);
+    public static ADMMObjectiveTerm createHingeLossTerm(Hyperplane<LocalVariable> hyperplane, Rule rule) {
+        return new ADMMObjectiveTerm(hyperplane,rule, false, true, null);
     }
 
-    public static ADMMObjectiveTerm createSquaredLinearLossTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule) {
-        return new ADMMObjectiveTerm(hyperplane, groundRule, true, false, null);
+    public static ADMMObjectiveTerm createSquaredLinearLossTerm(Hyperplane<LocalVariable> hyperplane, Rule rule) {
+        return new ADMMObjectiveTerm(hyperplane, rule, true, false, null);
     }
 
-    public static ADMMObjectiveTerm createSquaredHingeLossTerm(Hyperplane<LocalVariable> hyperplane, GroundRule groundRule) {
-        return new ADMMObjectiveTerm(hyperplane, groundRule, true, true, null);
+    public static ADMMObjectiveTerm createSquaredHingeLossTerm(Hyperplane<LocalVariable> hyperplane, Rule rule) {
+        return new ADMMObjectiveTerm(hyperplane, rule, true, true, null);
     }
 
     public void updateLagrange(float stepSize, float[] consensusValues) {
@@ -196,21 +194,26 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      * Modify the local variables to minimize this term (within the bounds of the step size).
      */
     public void minimize(float stepSize, float[] consensusValues) {
+        float weight = Float.POSITIVE_INFINITY;
+        if (rule != null && rule.isWeighted()) {
+            weight = ((WeightedRule)rule).getWeight();
+        }
+
         switch (getTermType()) {
             case LinearConstraintTerm:
                 minimizeConstraint(stepSize, consensusValues);
                 break;
             case LinearLossTerm:
-                minimizeLinearLoss(stepSize, consensusValues);
+                minimizeLinearLoss(stepSize, weight, consensusValues);
                 break;
             case HingeLossTerm:
-                minimizeHingeLoss(stepSize, consensusValues);
+                minimizeHingeLoss(stepSize, weight, consensusValues);
                 break;
             case SquaredLinearLossTerm:
-                minimizeSquaredLinearLoss(stepSize, consensusValues);
+                minimizeSquaredLinearLoss(stepSize, weight, consensusValues);
                 break;
             case SquaredHingeLossTerm:
-                minimizeSquaredHingeLoss(stepSize, consensusValues);
+                minimizeSquaredHingeLoss(stepSize, weight, consensusValues);
                 break;
             default:
                 throw new IllegalStateException("Unknown term type.");
@@ -221,17 +224,22 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      * Evaluate this potential using the local variables.
      */
     public float evaluate() {
+        float weight = Float.POSITIVE_INFINITY;
+        if (rule != null && rule.isWeighted()) {
+            weight = ((WeightedRule)rule).getWeight();
+        }
+
         switch (getTermType()) {
             case LinearConstraintTerm:
                 return evaluateConstraint();
             case LinearLossTerm:
-                return evaluateLinearLoss();
+                return evaluateLinearLoss(weight);
             case HingeLossTerm:
-                return evaluateHingeLoss();
+                return evaluateHingeLoss(weight);
             case SquaredLinearLossTerm:
-                return evaluateSquaredLinearLoss();
+                return evaluateSquaredLinearLoss(weight);
             case SquaredHingeLossTerm:
-                return evaluateSquaredHingeLoss();
+                return evaluateSquaredHingeLoss(weight);
             default:
                 throw new IllegalStateException("Unknown term type.");
         }
@@ -241,17 +249,22 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      * Evaluate this potential using the given consensus values.
      */
     public float evaluate(float[] consensusValues) {
+        float weight = Float.POSITIVE_INFINITY;
+        if (rule != null && rule.isWeighted()) {
+            weight = ((WeightedRule)rule).getWeight();
+        }
+
         switch (getTermType()) {
             case LinearConstraintTerm:
                 return evaluateConstraint(consensusValues);
             case LinearLossTerm:
-                return evaluateLinearLoss(consensusValues);
+                return evaluateLinearLoss(weight, consensusValues);
             case HingeLossTerm:
-                return evaluateHingeLoss(consensusValues);
+                return evaluateHingeLoss(weight, consensusValues);
             case SquaredLinearLossTerm:
-                return evaluateSquaredLinearLoss(consensusValues);
+                return evaluateSquaredLinearLoss(weight, consensusValues);
             case SquaredHingeLossTerm:
-                return evaluateSquaredHingeLoss(consensusValues);
+                return evaluateSquaredHingeLoss(weight, consensusValues);
             default:
                 throw new IllegalStateException("Unknown term type.");
         }
@@ -322,7 +335,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
 
     // Functionality for linear loss terms.
 
-    private void minimizeLinearLoss(float stepSize, float[] consensusValues) {
+    private void minimizeLinearLoss(float stepSize, float weight, float[] consensusValues) {
         // Linear losses can be directly minimized.
 
         for (int i = 0; i < size; i++) {
@@ -340,20 +353,20 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
     /**
      * weight * coefficients^T * local
      */
-    private float evaluateLinearLoss() {
+    private float evaluateLinearLoss(float weight) {
         return weight * computeInnerPotential();
     }
 
     /**
      * weight * coefficients^T * consensus
      */
-    private float evaluateLinearLoss(float[] consensusValues) {
+    private float evaluateLinearLoss(float weight, float[] consensusValues) {
         return weight * computeInnerPotential(consensusValues);
     }
 
     // Functionality for hinge-loss terms.
 
-    private void minimizeHingeLoss(float stepSize, float[] consensusValues) {
+    private void minimizeHingeLoss(float stepSize, float weight, float[] consensusValues) {
         // Look to see if the solution is in one of three sections (in increasing order of difficulty):
         // 1) The flat region.
         // 2) The linear region.
@@ -392,40 +405,40 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
     /**
      * weight * max(0.0, coefficients^T * local - constant)
      */
-    private float evaluateHingeLoss() {
+    private float evaluateHingeLoss(float weight) {
         return weight * Math.max(0.0f, computeInnerPotential());
     }
 
     /**
      * weight * max(0.0, coefficients^T * consensus - constant)
      */
-    private float evaluateHingeLoss(float[] consensusValues) {
+    private float evaluateHingeLoss(float weight, float[] consensusValues) {
         return weight * Math.max(0.0f, computeInnerPotential(consensusValues));
     }
 
     // Functionality for squared linear loss terms.
 
-    public void minimizeSquaredLinearLoss(float stepSize, float[] consensusValues) {
-        minWeightedSquaredHyperplane(stepSize, consensusValues);
+    private void minimizeSquaredLinearLoss(float stepSize, float weight, float[] consensusValues) {
+        minWeightedSquaredHyperplane(stepSize, weight, consensusValues);
     }
 
     /**
      * weight * (coefficients^T * local - constant)^2
      */
-    public float evaluateSquaredLinearLoss() {
+    private float evaluateSquaredLinearLoss(float weight) {
         return weight * (float)Math.pow(computeInnerPotential(), 2.0);
     }
 
     /**
      * weight * (coefficients^T * consensus - constant)^2
      */
-    public float evaluateSquaredLinearLoss(float[] consensusValues) {
+    private float evaluateSquaredLinearLoss(float weight, float[] consensusValues) {
         return weight * (float)Math.pow(computeInnerPotential(consensusValues), 2.0);
     }
 
     // Functionality for squared hinge-loss terms.
 
-    public void minimizeSquaredHingeLoss(float stepSize, float[] consensusValues) {
+    private void minimizeSquaredHingeLoss(float stepSize, float weight, float[] consensusValues) {
         // Take a gradient step and see if we are in the flat region.
         float total = 0.0f;
         for (int i = 0; i < size; i++) {
@@ -440,20 +453,20 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
         }
 
         // We are in the quadratic region, so solve that to find a solution.
-        minWeightedSquaredHyperplane(stepSize, consensusValues);
+        minWeightedSquaredHyperplane(stepSize, weight, consensusValues);
     }
 
     /**
      * weight * [max(0, coefficients^T * local - constant)]^2
      */
-    public float evaluateSquaredHingeLoss() {
+    private float evaluateSquaredHingeLoss(float weight) {
         return weight * (float)Math.pow(Math.max(0.0f, computeInnerPotential()), 2.0);
     }
 
     /**
      * weight * [max(0, coefficients^T * consensus - constant)]^2
      */
-    public float evaluateSquaredHingeLoss(float[] consensusValues) {
+    private float evaluateSquaredHingeLoss(float weight, float[] consensusValues) {
         return weight * (float)Math.pow(Math.max(0.0f, computeInnerPotential(consensusValues)), 2.0);
     }
 
@@ -484,7 +497,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
     /**
      * coefficients^T * local - constant
      */
-    protected float computeInnerPotential() {
+    private float computeInnerPotential() {
         float value = 0.0f;
         for (int i = 0; i < size; i++) {
             value += coefficients[i] * variables[i].getValue();
@@ -496,7 +509,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
     /**
      * coefficients^T * consensus - constant
      */
-    protected float computeInnerPotential(float[] consensusValues) {
+    private float computeInnerPotential(float[] consensusValues) {
         float value = 0.0f;
         for (int i = 0; i < size; i++) {
             value += coefficients[i] * consensusValues[variables[i].getGlobalId()];
@@ -513,7 +526,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      * while this hyperplane is: [coefficients^T * local = constant].
      * The result of the projection is stored in the local variables.
      */
-    protected void project(float stepSize, float[] consensusValues) {
+    private void project(float stepSize, float[] consensusValues) {
         // When there is only one variable, there is only one answer.
         // This answer must satisfy the constraint.
         if (size == 1) {
@@ -556,7 +569,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
      *
      * The result of the minimization will be stored in the local variables.
      */
-    protected void minWeightedSquaredHyperplane(float stepSize, float[] consensusValues) {
+    private void minWeightedSquaredHyperplane(float stepSize, float weight, float[] consensusValues) {
         // Different solving methods will be used depending on the size of the hyperplane.
 
         // Pre-load the local variable with a term that is common in all the solutions:
@@ -600,7 +613,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
 
         // In the case of larger hyperplanes, we can use a Cholesky decomposition to minimize.
 
-        FloatMatrix lowerTriangle = fetchLowerTriangle(stepSize);
+        FloatMatrix lowerTriangle = fetchLowerTriangle(stepSize, weight);
 
         for (int i = 0; i < size; i++) {
             float newValue = variables[i].getValue();
@@ -626,7 +639,7 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
     /**
      * Get the lower triangle if it already exists, compute and cache it otherwise.
      */
-    private FloatMatrix fetchLowerTriangle(float stepSize) {
+    private FloatMatrix fetchLowerTriangle(float stepSize, float weight) {
         int hash = HashCode.build(weight);
         hash = HashCode.build(hash, stepSize);
         for (int i = 0; i < size; i++) {
@@ -641,14 +654,14 @@ public class ADMMObjectiveTerm implements ReasonerTerm {
         }
 
         // If we didn't find it, then synchronize and compute it on this thread.
-        return computeLowerTriangle(stepSize, hash);
+        return computeLowerTriangle(stepSize, weight, hash);
     }
 
     /**
      * Actually copute the lower triangle and store it in the cache.
      * There is one triangle per rule, so most ground rules will just pull off the same cache.
      */
-    private synchronized FloatMatrix computeLowerTriangle(float stepSize, int hash) {
+    private synchronized FloatMatrix computeLowerTriangle(float stepSize, float weight, int hash) {
         // There is still a race condition in the map fetch before getting here,
         // so we will check one more time while synchronized.
         if (lowerTriangleCache.containsKey(hash)) {

--- a/psl-core/src/main/java/org/linqs/psl/reasoner/admm/term/ADMMTermGenerator.java
+++ b/psl-core/src/main/java/org/linqs/psl/reasoner/admm/term/ADMMTermGenerator.java
@@ -43,13 +43,13 @@ public class ADMMTermGenerator extends HyperplaneTermGenerator<ADMMObjectiveTerm
     public int createLossTerm(Collection<ADMMObjectiveTerm> newTerms, TermStore<ADMMObjectiveTerm, LocalVariable> termStore,
             boolean isHinge, boolean isSquared, GroundRule groundRule, Hyperplane<LocalVariable> hyperplane) {
         if (isHinge && isSquared) {
-            newTerms.add(ADMMObjectiveTerm.createSquaredHingeLossTerm(hyperplane, groundRule));
+            newTerms.add(ADMMObjectiveTerm.createSquaredHingeLossTerm(hyperplane, groundRule.getRule()));
         } else if (isHinge && !isSquared) {
-            newTerms.add(ADMMObjectiveTerm.createHingeLossTerm(hyperplane, groundRule));
+            newTerms.add(ADMMObjectiveTerm.createHingeLossTerm(hyperplane, groundRule.getRule()));
         } else if (!isHinge && isSquared) {
-            newTerms.add(ADMMObjectiveTerm.createSquaredLinearLossTerm(hyperplane, groundRule));
+            newTerms.add(ADMMObjectiveTerm.createSquaredLinearLossTerm(hyperplane, groundRule.getRule()));
         } else {
-            newTerms.add(ADMMObjectiveTerm.createLinearLossTerm(hyperplane, groundRule));
+            newTerms.add(ADMMObjectiveTerm.createLinearLossTerm(hyperplane, groundRule.getRule()));
         }
 
         return 1;
@@ -58,7 +58,7 @@ public class ADMMTermGenerator extends HyperplaneTermGenerator<ADMMObjectiveTerm
     @Override
     public int createLinearConstraintTerm(Collection<ADMMObjectiveTerm> newTerms, TermStore<ADMMObjectiveTerm, LocalVariable> termStore,
             GroundRule groundRule, Hyperplane<LocalVariable> hyperplane, FunctionComparator comparator) {
-        newTerms.add(ADMMObjectiveTerm.createLinearConstraintTerm(hyperplane, groundRule, comparator));
+        newTerms.add(ADMMObjectiveTerm.createLinearConstraintTerm(hyperplane, groundRule.getRule(), comparator));
         return 1;
     }
 }

--- a/psl-core/src/main/java/org/linqs/psl/reasoner/sgd/term/SGDTermGenerator.java
+++ b/psl-core/src/main/java/org/linqs/psl/reasoner/sgd/term/SGDTermGenerator.java
@@ -54,8 +54,7 @@ public class SGDTermGenerator extends HyperplaneTermGenerator<SGDObjectiveTerm, 
     public int createLossTerm(Collection<SGDObjectiveTerm> newTerms, TermStore<SGDObjectiveTerm, RandomVariableAtom> baseTermStore,
             boolean isHinge, boolean isSquared, GroundRule groundRule, Hyperplane<RandomVariableAtom> hyperplane) {
         VariableTermStore<SGDObjectiveTerm, RandomVariableAtom> termStore = (VariableTermStore<SGDObjectiveTerm, RandomVariableAtom>)baseTermStore;
-        float weight = (float)((WeightedGroundRule)groundRule).getWeight();
-        newTerms.add(new SGDObjectiveTerm(termStore, isSquared, isHinge, hyperplane, weight, learningRate));
+        newTerms.add(new SGDObjectiveTerm(termStore, ((WeightedGroundRule)groundRule).getRule(), isSquared, isHinge, hyperplane, learningRate));
         return 1;
     }
 

--- a/psl-core/src/main/java/org/linqs/psl/reasoner/term/MemoryVariableTermStore.java
+++ b/psl-core/src/main/java/org/linqs/psl/reasoner/term/MemoryVariableTermStore.java
@@ -21,19 +21,14 @@ import org.linqs.psl.config.Options;
 import org.linqs.psl.model.atom.RandomVariableAtom;
 import org.linqs.psl.model.predicate.model.ModelPredicate;
 import org.linqs.psl.model.rule.GroundRule;
-import org.linqs.psl.reasoner.term.MemoryTermStore;
-import org.linqs.psl.reasoner.term.VariableTermStore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/ADMMObjectiveTermTest.java
+++ b/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/ADMMObjectiveTermTest.java
@@ -237,19 +237,19 @@ public class ADMMObjectiveTermTest {
         } else if (!squared && !hinge) {
             term = ADMMObjectiveTerm.createLinearLossTerm(
                     new Hyperplane<LocalVariable>(variables, coeffs, 0.0f, consensus.length),
-                    new FakeGroundRule(weight));
+                    new FakeRule(weight, squared));
         } else if (!squared && hinge) {
             term = ADMMObjectiveTerm.createHingeLossTerm(
                     new Hyperplane<LocalVariable>(variables, coeffs, constant, consensus.length),
-                    new FakeGroundRule(weight));
+                    new FakeRule(weight, squared));
         } else if (squared && !hinge) {
             term = ADMMObjectiveTerm.createSquaredLinearLossTerm(
                     new Hyperplane<LocalVariable>(variables, coeffs, constant, consensus.length),
-                    new FakeGroundRule(weight));
+                    new FakeRule(weight, squared));
         } else if (squared && hinge) {
             term = ADMMObjectiveTerm.createSquaredHingeLossTerm(
                     new Hyperplane<LocalVariable>(variables, coeffs, constant, consensus.length),
-                    new FakeGroundRule(weight));
+                    new FakeRule(weight, squared));
         }
 
         term.minimize(stepSize, consensus);

--- a/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/FakeGroundRule.java
+++ b/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/FakeGroundRule.java
@@ -27,10 +27,10 @@ import java.util.List;
 import java.util.Set;
 
 public class FakeGroundRule implements WeightedGroundRule {
-    private float weight;
+    private FakeRule rule;
 
-    public FakeGroundRule(float weight) {
-        this.weight = weight;
+    public FakeGroundRule(FakeRule rule) {
+        this.rule = rule;
     }
 
     @Override
@@ -45,7 +45,7 @@ public class FakeGroundRule implements WeightedGroundRule {
 
     @Override
     public WeightedRule getRule() {
-        return null;
+        return rule;
     }
 
     @Override
@@ -55,12 +55,12 @@ public class FakeGroundRule implements WeightedGroundRule {
 
     @Override
     public float getWeight() {
-        return weight;
+        return rule.getWeight();
     }
 
     @Override
     public void setWeight(float weight) {
-        this.weight = weight;
+        this.rule.setWeight(weight);
     }
 
     @Override

--- a/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/FakeRule.java
+++ b/psl-core/src/test/java/org/linqs/psl/reasoner/admm/term/FakeRule.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the PSL software.
+ * Copyright 2011-2015 University of Maryland
+ * Copyright 2013-2020 The Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.linqs.psl.reasoner.admm.term;
+
+import org.linqs.psl.database.atom.AtomManager;
+import org.linqs.psl.database.rdbms.RawQuery;
+import org.linqs.psl.grounding.GroundRuleStore;
+import org.linqs.psl.model.formula.Formula;
+import org.linqs.psl.model.rule.AbstractRule;
+import org.linqs.psl.model.rule.GroundRule;
+import org.linqs.psl.model.rule.WeightedRule;
+import org.linqs.psl.model.term.Constant;
+import org.linqs.psl.model.term.Variable;
+import org.linqs.psl.util.MathUtils;
+
+import java.util.List;
+import java.util.Map;
+
+public class FakeRule extends AbstractRule implements WeightedRule {
+    protected float weight;
+    protected boolean squared;
+
+    public FakeRule(float weight, boolean squared) {
+        super("fake");
+
+        this.weight = weight;
+        this.squared = squared;
+    }
+
+    @Override
+    public boolean isSquared() {
+        return squared;
+    }
+
+    @Override
+    public float getWeight() {
+        return weight;
+    }
+
+    @Override
+    public void setWeight(float weight) {
+        this.weight = weight;
+    }
+
+    @Override
+    public String toString() {
+        return "fake";
+    }
+
+    @Override
+    public long groundAll(AtomManager atomManager, GroundRuleStore groundRuleStore) {
+        return 0;
+    }
+
+    @Override
+    public boolean isWeighted() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsGroundingQueryRewriting() {
+        return false;
+    }
+
+    @Override
+    public Formula getRewritableGroundingFormula(AtomManager atomManager) {
+        return null;
+    }
+
+    @Override
+    public boolean supportsIndividualGrounding() {
+        return false;
+    }
+
+    @Override
+    public RawQuery getGroundingQuery(AtomManager atomManager) {
+        return null;
+    }
+
+    @Override
+    public void ground(Constant[] constants, Map<Variable, Integer> variableMap, AtomManager atomManager, List<GroundRule> results) {
+        // Pass.
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+
+        FakeRule otherRule = (FakeRule)other;
+        if (this.squared != otherRule.squared || !MathUtils.equals(this.weight, otherRule.weight)) {
+            return false;
+        }
+
+        return super.equals(other);
+    }
+}


### PR DESCRIPTION
Weight learning applications update rule weights. Reasoners were optimizing over terms with weights copied from initialization that were not updated when rule weights were updated, i.e., the weight learning application was running optimization repeatedly over unmodified terms. The commit that introduced this problem for ADMM seems to be: [Cleaned up the ADMM hyperplane projection code.](https://github.com/linqs/psl/commit/f3aa580cc9122a3792fef39ef828df75584f6a54), weight learning applications with SGD reasoners may have never updated term weights.