### PR TITLE
Remove unnecessary passing of DataStore object to ModelLoader.

### DIFF
--- a/psl-cli/src/main/java/org/linqs/psl/cli/Launcher.java
+++ b/psl-cli/src/main/java/org/linqs/psl/cli/Launcher.java
@@ -349,7 +349,7 @@ public class Launcher {
         Evaluator evaluator = (Evaluator)Reflection.newObject(evalClassName);
 
         for (StandardPredicate targetPredicate : openPredicates) {
-            // Before we run evaluation, ensure that the truth database actaully has instances of the target predicate.
+            // Before we run evaluation, ensure that the truth database actually has instances of the target predicate.
             if (truthDatabase.countAllGroundAtoms(targetPredicate) == 0) {
                 log.info("Skipping evaluation for {} since there are no ground truth atoms", targetPredicate);
                 continue;
@@ -365,13 +365,13 @@ public class Launcher {
         truthDatabase.close();
     }
 
-    private Model loadModel(DataStore dataStore) {
+    private Model loadModel() {
         log.info("Loading model from {}", parsedOptions.getOptionValue(CommandLineLoader.OPTION_MODEL));
 
         Model model = null;
 
         try (FileReader reader = new FileReader(new File(parsedOptions.getOptionValue(CommandLineLoader.OPTION_MODEL)))) {
-            model = ModelLoader.load(dataStore, reader);
+            model = ModelLoader.load(reader);
         } catch (IOException ex) {
             throw new RuntimeException("Failed to load model from file: " + parsedOptions.getOptionValue(CommandLineLoader.OPTION_MODEL), ex);
         }
@@ -394,7 +394,7 @@ public class Launcher {
         Set<StandardPredicate> closedPredicates = loadData(dataStore);
 
         // Load model
-        Model model = loadModel(dataStore);
+        Model model = loadModel();
 
         // Inference
         Database evalDB = null;

--- a/psl-java/src/main/java/org/linqs/psl/java/PSLModel.java
+++ b/psl-java/src/main/java/org/linqs/psl/java/PSLModel.java
@@ -65,7 +65,7 @@ public class PSLModel extends Model {
      * Add a rule that is fully specified in string form.
      */
     public Rule addRule(String ruleString) {
-        Rule rule = ModelLoader.loadRule(dataStore, ruleString);
+        Rule rule = ModelLoader.loadRule(ruleString);
         addRule(rule);
         return rule;
     }
@@ -88,7 +88,7 @@ public class PSLModel extends Model {
      * Add a rule that has the body in string form, but the additional traits (weight/squared) unspecified.
      */
     public Rule addRule(String ruleString, boolean weighted, float weight, boolean squared) {
-        RulePartial rulePartial = ModelLoader.loadRulePartial(dataStore, ruleString);
+        RulePartial rulePartial = ModelLoader.loadRulePartial(ruleString);
 
         Rule rule = null;
 
@@ -116,7 +116,7 @@ public class PSLModel extends Model {
     public List<Rule> addRules(Reader rules) {
         List<Rule> addedRules = new ArrayList<Rule>();
 
-        Model model = ModelLoader.load(dataStore, rules);
+        Model model = ModelLoader.load(rules);
         for (Rule rule : model.getRules()) {
             addRule(rule);
             addedRules.add(rule);

--- a/psl-parser/src/main/java/org/linqs/psl/parser/ModelLoader.java
+++ b/psl-parser/src/main/java/org/linqs/psl/parser/ModelLoader.java
@@ -17,7 +17,6 @@
  */
 package org.linqs.psl.parser;
 
-import org.linqs.psl.database.DataStore;
 import org.linqs.psl.model.Model;
 import org.linqs.psl.model.atom.Atom;
 import org.linqs.psl.model.atom.QueryAtom;
@@ -103,15 +102,12 @@ import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.atn.ParserATNSimulator;
-import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import java.io.Reader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -121,7 +117,7 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
     /**
      * Parse a string into either a full PSL Rule or a rule without weight or potential squaring information.
      */
-    public static RulePartial loadRulePartial(DataStore data, String input) {
+    public static RulePartial loadRulePartial(String input) {
         PSLParser parser = null;
         try {
             parser = getParser(input);
@@ -138,7 +134,7 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
             throw (RuntimeException)ex.getCause();
         }
 
-        ModelLoader visitor = new ModelLoader(data);
+        ModelLoader visitor = new ModelLoader();
         return visitor.visitPslRulePartial(context);
     }
 
@@ -146,8 +142,8 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
      * Parse and return a single rule.
      * If exactly one rule is not specified, an exception is thrown.
      */
-    public static Rule loadRule(DataStore data, String input) {
-        Model model = load(data, new StringReader(input));
+    public static Rule loadRule(String input) {
+        Model model = load(new StringReader(input));
 
         int ruleCount = 0;
         Rule targetRule = null;
@@ -169,8 +165,8 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
     /**
      * Convenience interface to load().
      */
-    public static Model load(DataStore data, String input) {
-        return load(data, new StringReader(input));
+    public static Model load(String input) {
+        return load(new StringReader(input));
     }
 
     /**
@@ -178,7 +174,7 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
      * The input should only contain rules and the DataStore should contain all the predicates
      * used by the rules.
      */
-    public static Model load(DataStore data, Reader input) {
+    public static Model load(Reader input) {
         PSLParser parser = null;
         try {
             parser = getParser(input);
@@ -195,7 +191,7 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
             throw (RuntimeException)ex.getCause();
         }
 
-        ModelLoader visitor = new ModelLoader(data);
+        ModelLoader visitor = new ModelLoader();
         return visitor.visitProgram(program, parser);
     }
 
@@ -232,11 +228,7 @@ public class ModelLoader extends PSLBaseVisitor<Object> {
 
     // Non-static
 
-    private final DataStore data;
-
-    private ModelLoader(DataStore data) {
-        this.data = data;
-    }
+    private ModelLoader() {}
 
     public Model visitProgram(ProgramContext ctx, PSLParser parser) {
         Model model = new Model();

--- a/psl-parser/src/test/java/org/linqs/psl/PSLTest.java
+++ b/psl-parser/src/test/java/org/linqs/psl/PSLTest.java
@@ -18,9 +18,7 @@
 package org.linqs.psl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
-import org.linqs.psl.database.DataStore;
 import org.linqs.psl.model.Model;
 import org.linqs.psl.model.rule.Rule;
 import org.linqs.psl.parser.ModelLoader;
@@ -36,8 +34,8 @@ public class PSLTest {
     /**
      * Convenience call for the common functionality of assertRule() (alphabetize).
      */
-    public static void assertRule(DataStore dataStore, String input, String expectedRule) {
-        assertRule(dataStore, input, expectedRule, true);
+    public static void assertRule(String input, String expectedRule) {
+        assertRule(input, expectedRule, true);
     }
 
     /**
@@ -49,14 +47,14 @@ public class PSLTest {
      * characters in both strings (actual and expected) before comparing.
      * Only alphabetize if it is really necessary since it makes the output much harder to interpret.
      */
-    public static void assertRule(DataStore dataStore, String input, String expectedRule, boolean alphabetize) {
+    public static void assertRule(String input, String expectedRule, boolean alphabetize) {
         Rule rule = null;
 
-        rule = ModelLoader.loadRule(dataStore, input);
+        rule = ModelLoader.loadRule(input);
         assertRule(rule, expectedRule, alphabetize);
 
         // Now ensure that we can load the string version of the created rule.
-        rule = ModelLoader.loadRule(dataStore, rule.toString());
+        rule = ModelLoader.loadRule(rule.toString());
         assertRule(rule, expectedRule, alphabetize);
     }
 
@@ -113,8 +111,8 @@ public class PSLTest {
     /**
      * Convenience call for the common functionality of assertModel() (alphabetize).
      */
-    public static void assertModel(DataStore dataStore, String input, String[] expectedRules) {
-        assertModel(dataStore, input, expectedRules, true);
+    public static void assertModel(String input, String[] expectedRules) {
+        assertModel(input, expectedRules, true);
     }
 
     /**
@@ -125,8 +123,8 @@ public class PSLTest {
      * characters in both strings (actual and expected) before comparing.
      * Only alphabetize if it is really necessary since it makes the output much harder to interpret.
      */
-    public static void assertModel(DataStore dataStore, String input, String[] expectedRules, boolean alphabetize) {
-        Model model = ModelLoader.load(dataStore, input);
+    public static void assertModel(String input, String[] expectedRules, boolean alphabetize) {
+        Model model = ModelLoader.load(input);
 
         List<Rule> rules = new ArrayList<Rule>();
         for (Rule rule : model.getRules()) {
@@ -138,7 +136,7 @@ public class PSLTest {
         // Try again with each rule, but use the generated text for each rule.
         for (int i = 0; i < rules.size(); i++) {
             try {
-                assertRule(dataStore, rules.get(i).toString(), expectedRules[i], alphabetize);
+                assertRule(rules.get(i).toString(), expectedRules[i], alphabetize);
             } catch (org.antlr.v4.runtime.RecognitionException ex) {
                 throw new RuntimeException("toString() rule did not parse: " + rules.get(i).toString(), ex);
             }
@@ -149,8 +147,8 @@ public class PSLTest {
      * A weaker variant of assertModel() that only uses sorted strings for comparison.
      * Use when you can't give guarentees on both the order of rules and format of each rule.
      */
-    public static void assertStringModel(DataStore dataStore, String input, String[] expectedRules, boolean alphabetize) {
-        Model model = ModelLoader.load(dataStore, input);
+    public static void assertStringModel(String input, String[] expectedRules, boolean alphabetize) {
+        Model model = ModelLoader.load(input);
 
         List<String> rules = new ArrayList<String>();
         for (Rule rule : model.getRules()) {
@@ -176,8 +174,8 @@ public class PSLTest {
         }
     }
 
-    public static List<Rule> getRules(DataStore dataStore, String input) {
-        Model model = ModelLoader.load(dataStore, input);
+    public static List<Rule> getRules(String input) {
+        Model model = ModelLoader.load(input);
 
         List<Rule> rules = new ArrayList<Rule>();
         for (Rule rule : model.getRules()) {

--- a/psl-parser/src/test/java/org/linqs/psl/parser/ModelLoaderTest.java
+++ b/psl-parser/src/test/java/org/linqs/psl/parser/ModelLoaderTest.java
@@ -68,7 +68,7 @@ public class ModelLoaderTest {
             "5.0: ( SINGLE(B) & DOUBLE(B, A) ) >> SINGLE(A) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ModelLoaderTest {
             "~( SINGLE(A) ) ."
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ModelLoaderTest {
         String input = String.format("1: %s >> Single(Z) ^2", ListUtils.join(" & ", parts));
         String expected = String.format("1.0: ( %s ) >> SINGLE(Z) ^2", ListUtils.join(" & ", parts).toUpperCase());
 
-        PSLTest.assertModel(dataStore, input, new String[]{expected});
+        PSLTest.assertModel(input, new String[]{expected});
     }
 
     @Test
@@ -135,7 +135,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(K) & DOUBLE(K, L) ) >> SINGLE(L) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(A) & DOUBLE(A, '_A_B_') & SINGLE('_A_B_') ) >> DOUBLE(A, '_A_B_') ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -237,7 +237,7 @@ public class ModelLoaderTest {
             "1.0: -1200000.0 * SINGLE(A) = 1.0 ^2",
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -258,7 +258,7 @@ public class ModelLoaderTest {
             "1.0: SINGLE(A__) >> SINGLE(A__) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -295,7 +295,7 @@ public class ModelLoaderTest {
             "2.5E-6: SINGLE(M) >> SINGLE(M)"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(C) & DOUBLE(C, D) ) >> SINGLE(D) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -321,7 +321,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(A) & DOUBLE(B, C) ) >> ( SINGLE(B) | SINGLE(C) ) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     /**
@@ -343,17 +343,17 @@ public class ModelLoaderTest {
             "1.0: ( ~( SINGLE(G) ) & ~( ~( DOUBLE(G, H) ) ) ) >> ~( ~( ~( SINGLE(H) ) ) ) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
 
         try {
-            PSLTest.assertRule(dataStore, "1: ~( Single(A) & Single(B) ) >> Double(A, B) ^2", "");
+            PSLTest.assertRule("1: ~( Single(A) & Single(B) ) >> Double(A, B) ^2", "");
             fail("Negation not allowed on a conjunction.");
         } catch (org.antlr.v4.runtime.RecognitionException ex) {
             // Exception expected.
         }
 
         try {
-            PSLTest.assertRule(dataStore, "1: Double(A, B) >> ~( Single(A) | Single(B) ) ^2", "");
+            PSLTest.assertRule("1: Double(A, B) >> ~( Single(A) | Single(B) ) ^2", "");
             fail("Negation not allowed on a disjunction.");
         } catch (org.antlr.v4.runtime.RecognitionException ex) {
             // Exception expected.
@@ -383,7 +383,7 @@ public class ModelLoaderTest {
             "1.0: ( ('Foo' != 'Bar') & DOUBLE(A, B) ) >> SINGLE(B) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -413,7 +413,7 @@ public class ModelLoaderTest {
             "1.0: ( (U != V) & DOUBLE(U, V) ) >> SINGLE(V)"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -427,7 +427,7 @@ public class ModelLoaderTest {
             // "1.0: 1.0 * SINGLE(A) = 1.0 ^2"  // Duplicate rule ignored.
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -467,21 +467,21 @@ public class ModelLoaderTest {
             "0.0 * SINGLE(A) = 1.0 ."
         };
 
-        PSLTest.assertStringModel(dataStore, input, expected, true);
+        PSLTest.assertStringModel(input, expected, true);
     }
 
     @Test
     public void testLoadRuleBase() {
         String input = "1: Single(A) & Double(A, B) >> Single(B) ^2";
         String expected = "1.0: ( SINGLE(A) & DOUBLE(A, B) ) >> SINGLE(B) ^2";
-        PSLTest.assertRule(dataStore, input, expected);
+        PSLTest.assertRule(input, expected);
     }
 
     @Test
     public void testLoadRuleBadCount() {
         // Having zero rules is a parse error, so the exception is different.
         try {
-            PSLTest.assertRule(dataStore, "// Just a comment", "");
+            PSLTest.assertRule("// Just a comment", "");
             fail("ModelLoader.LoadRule() with no rule did not throw an exception.");
         } catch (org.antlr.v4.runtime.NoViableAltException ex) {
             // Exception expected.
@@ -493,7 +493,7 @@ public class ModelLoaderTest {
         String expected = "1.0: ( SINGLE(A) & DOUBLE(A, B) ) >> SINGLE(B) ^2";
 
         try {
-            PSLTest.assertRule(dataStore, input, expected);
+            PSLTest.assertRule(input, expected);
             fail("ModelLoader.LoadRule() with more than one rule did not throw an exception.");
         } catch (IllegalArgumentException ex) {
             // Exception expected.
@@ -514,7 +514,7 @@ public class ModelLoaderTest {
 
         for (int i = 0; i < input.length; i++) {
             try {
-                PSLTest.assertRule(dataStore, input[i], expected[i]);
+                PSLTest.assertRule(input[i], expected[i]);
                 fail(String.format("Rule: %d - Exception not thrown when float used without leading digit.", i));
             } catch (Exception ex) {
                 // Exception expected.
@@ -552,7 +552,7 @@ public class ModelLoaderTest {
 
         for (int i = 0; i < input.length; i++) {
             try {
-                PSLTest.assertRule(dataStore, input[i], expected[i]);
+                PSLTest.assertRule(input[i], expected[i]);
                 fail(String.format("Rule: %d - Exception not thrown on general syntax error.", i));
             } catch (Exception ex) {
                 // Exception expected.
@@ -582,7 +582,7 @@ public class ModelLoaderTest {
 
         for (int i = 0; i < input.length; i++) {
             try {
-                PSLTest.assertRule(dataStore, input[i], expected[i]);
+                PSLTest.assertRule(input[i], expected[i]);
                 fail(String.format("Rule: %d - Exception not thrown on bad square error.", i));
             } catch (Exception ex) {
                 // Exception expected.
@@ -614,7 +614,7 @@ public class ModelLoaderTest {
         };
 
         for (int i = 0; i < inputs.length; i++) {
-            RulePartial partial = ModelLoader.loadRulePartial(dataStore, inputs[i]);
+            RulePartial partial = ModelLoader.loadRulePartial(inputs[i]);
             assertEquals(
                     String.format("Expected RulePartial #%d to be a rule, but was not.", i),
                     true,
@@ -653,7 +653,7 @@ public class ModelLoaderTest {
         };
 
         for (int i = 0; i < inputs.length; i++) {
-            RulePartial partial = ModelLoader.loadRulePartial(dataStore, inputs[i]);
+            RulePartial partial = ModelLoader.loadRulePartial(inputs[i]);
             assertEquals(
                     String.format("Expected RulePartial #%d to not a rule, but was.", i),
                     false,
@@ -681,7 +681,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(C) & SINGLE(D) & (C % D) ) >> DOUBLE(C, D) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -729,7 +729,7 @@ public class ModelLoaderTest {
             "1.0 * SINGLE(A) = 99.0 ."
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -756,7 +756,7 @@ public class ModelLoaderTest {
             "1.0: ( (O != P) & SINGLE(O) & SINGLE(P) ) >> DOUBLE(O, P) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -815,7 +815,7 @@ public class ModelLoaderTest {
             "21.0 * SINGLE(+A) + 21.0 * DOUBLE(B, C) = 1.0 .   {A : ( SINGLE(A) & SINGLE(C) )}",
         };
 
-        PSLTest.assertStringModel(dataStore, input, expected, true);
+        PSLTest.assertStringModel(input, expected, true);
     }
 
     @Test
@@ -833,7 +833,7 @@ public class ModelLoaderTest {
             "-1.0 * DOUBLE(A, B) + -1.0 * DOUBLE(B, A) = 0.0 ."
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -863,7 +863,7 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE(Q) & SINGLE(R) & DOUBLE(R, Q) ) >> DOUBLE(Q, R)",
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -877,7 +877,7 @@ public class ModelLoaderTest {
             // "1.0 * SINGLE(A) + 1.0 * SINGLE(B) = 0.0 ."  // Duplicate rule ignored.
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -892,7 +892,7 @@ public class ModelLoaderTest {
 
         for (String rule : input) {
             try {
-                PSLTest.assertRule(dataStore, rule, "");
+                PSLTest.assertRule(rule, "");
                 fail("Divide by zero did not throw exception.");
             } catch (RuntimeException ex) {
                 if (!(ex.getCause() instanceof ArithmeticException)) {
@@ -908,7 +908,7 @@ public class ModelLoaderTest {
     public void testArithmeticSummationAtom() {
         // QueryAtom
         String input = "1.0: Double(A, B) <= 1.0 ^2";
-        List<Rule> rules = PSLTest.getRules(dataStore, input);
+        List<Rule> rules = PSLTest.getRules(input);
 
         assertEquals(1, rules.size());
         assertEquals(WeightedArithmeticRule.class, rules.get(0).getClass());
@@ -920,7 +920,7 @@ public class ModelLoaderTest {
 
         // SummationAtom
         input = "1.0: Double(+A, B) <= 1.0 ^2";
-        rules = PSLTest.getRules(dataStore, input);
+        rules = PSLTest.getRules(input);
 
         assertEquals(1, rules.size());
         assertEquals(WeightedArithmeticRule.class, rules.get(0).getClass());
@@ -941,7 +941,7 @@ public class ModelLoaderTest {
             "-5.2: ( SINGLE(B) & DOUBLE(B, A) ) >> SINGLE(A) ^2"
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 
     @Test
@@ -995,6 +995,6 @@ public class ModelLoaderTest {
             "1.0: ( SINGLE('<,>.?/') & DOUBLE(Z, B) ) >> SINGLE(B) ^2",
         };
 
-        PSLTest.assertModel(dataStore, input, expected);
+        PSLTest.assertModel(input, expected);
     }
 }


### PR DESCRIPTION
This is a part of the changes made in the larger onlinePSL project.

A dataStore object was being unnecessarily passed to the constructor and some of the static methods of the ModelLoader class. 