### PR TITLE
Maintain a count of the number of observed atoms instantiated.

### DIFF
--- a/psl-core/src/main/java/org/linqs/psl/database/Database.java
+++ b/psl-core/src/main/java/org/linqs/psl/database/Database.java
@@ -207,7 +207,7 @@ public abstract class Database implements ReadableDatabase, WritableDatabase {
         List<RandomVariableAtom> atoms = new ArrayList<RandomVariableAtom>(groundAtoms.size());
         for (GroundAtom atom : groundAtoms) {
             // This is only possible if the predicate is partially observed and this ground atom
-            // was specified as a target and an observation/
+            // was specified as a target and an observation.
             if (atom instanceof ObservedAtom) {
                 throw new IllegalStateException(String.format(
                         "Found a ground atom (%s) that is both observed and a target." +
@@ -276,7 +276,7 @@ public abstract class Database implements ReadableDatabase, WritableDatabase {
     /**
      * @return the DataStore backing this Database
      */
-    public DataStore getDataStore(){
+    public DataStore getDataStore() {
         return parentDataStore;
     }
 

--- a/psl-core/src/main/java/org/linqs/psl/database/Database.java
+++ b/psl-core/src/main/java/org/linqs/psl/database/Database.java
@@ -342,4 +342,8 @@ public abstract class Database implements ReadableDatabase, WritableDatabase {
     public int getCachedRVACount() {
         return cache.getRVACount();
     }
+
+    public int getCachedObsCount() {
+        return cache.getObsCount();
+    }
 }

--- a/psl-core/src/main/java/org/linqs/psl/database/atom/AtomCache.java
+++ b/psl-core/src/main/java/org/linqs/psl/database/atom/AtomCache.java
@@ -48,8 +48,9 @@ public class AtomCache {
 
     protected final Map<QueryAtom, GroundAtom> cache;
 
-    // The number of random variable atoms that have been instantiated.
+    // The number of random variable and observed atoms that have been instantiated.
     private int rvaCount;
+    private int obsCount;
 
     /**
      * Constructs a new AtomCache for a Database.
@@ -60,6 +61,7 @@ public class AtomCache {
         this.db = db;
         this.cache = new HashMap<QueryAtom, GroundAtom>();
         this.rvaCount = 0;
+        this.obsCount = 0;
     }
 
     /**
@@ -82,6 +84,10 @@ public class AtomCache {
 
     public int getRVACount() {
         return rvaCount;
+    }
+
+    public int getObsCount() {
+        return obsCount;
     }
 
     /**
@@ -110,6 +116,8 @@ public class AtomCache {
 
             if (atom instanceof RandomVariableAtom) {
                 rvaCount--;
+            } else if (atom instanceof ObservedAtom) {
+                obsCount--;
             }
 
             return true;
@@ -162,6 +170,7 @@ public class AtomCache {
 
         ObservedAtom atom = new ObservedAtom(predicate, args, value);
         cache.put(key, atom);
+        obsCount++;
 
         return atom;
     }

--- a/psl-core/src/main/java/org/linqs/psl/database/atom/AtomManager.java
+++ b/psl-core/src/main/java/org/linqs/psl/database/atom/AtomManager.java
@@ -119,6 +119,13 @@ public abstract class AtomManager {
     }
 
     /**
+     * Get the number of ObservedAtoms cached by the database.
+     */
+    public int getCachedObsCount() {
+        return db.getCachedObsCount();
+    }
+
+    /**
      * Decide whether or not to throw an access exception.
      * This will bypass |enableAccessExceptions|.
      */

--- a/psl-core/src/main/java/org/linqs/psl/database/atom/AtomManager.java
+++ b/psl-core/src/main/java/org/linqs/psl/database/atom/AtomManager.java
@@ -60,6 +60,7 @@ public abstract class AtomManager {
      *
      * This method must call {@link Database#getAtom(Predicate, Constant...)}
      * to actually retrieve the GroundAtom.
+     * Atom managers reserve the right to reject any atom by returning null here.
      *
      * @param predicate the Predicate of the Atom
      * @param arguments the GroundTerms of the Atom


### PR DESCRIPTION
This is a part of the changes made in the larger onlinePSL project.

Maintain a count of the number of observed atoms instantiated in the AtomCache and create methods for accessing this count from AtomManagers and Databases. This is used by onlinePSL to ensure capacity for certain data structures.