### PR TITLE
Change DataFrame.append (deprecated) to Pandas.concat

### DIFF
--- a/psl-python/pslpython/predicate.py
+++ b/psl-python/pslpython/predicate.py
@@ -166,7 +166,7 @@ class Predicate(object):
             # Missing the truth value.
             data[size] = Predicate.DEFAULT_TRUTH_VALUE
             
-        self._data[partition] = self._data[partition].append(data, ignore_index = True)
+        self._data[partition] = pandas.concat([self._data[partition], data], ignore_index = True)
 
         return self
 


### PR DESCRIPTION
Pandas deprecates DataFrame.append since version 1.4.0. This updates will make the annoying FutureWarning goes away every time new data is added to the model.