### PR TITLE
Update setup.py to allow JPype1 versions >= 1.4.0

### DIFF
--- a/psl-python/setup.py
+++ b/psl-python/setup.py
@@ -111,7 +111,7 @@ def main():
         },
 
         install_requires = [
-            'JPype1==1.4.0',
+            'JPype1>=1.4.0',
             'pandas>=0.24.1',
         ],
 


### PR DESCRIPTION
The change from JPype1==1.4.0 to JPype1>=1.4.0 in setup.py is made to ensure compatibility with Python 3.11, as JPype1 1.4.0 does not support it. JPype1 1.4.1 already provides support for Python 3.11, making it a better choice to specify a minimum version while allowing for future updates.